### PR TITLE
Mark as end-of-life, and direct to official Microsoft app.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,5 @@
 {
+    "end-of-life": "The Flatpak for this unofficial Teams app is unmaintained",
+    "end-of-life-rebase": "com.microsoft.Teams",
     "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Sadly, it seems that no-one is taking the time to keep this Flatpak package up to date.  There are reports in #15 that it no-longer works.  This being the case, it’s probably best to reluctantly retire it.

I couldn’t find any documentation on how to retire a package from Flathub, but I found a few examples that follow this pattern, so hopefully I got it right.

Fixes #14.