### PR TITLE
Bump freedesktop to 22.08 (under testing)

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -1,8 +1,8 @@
 app-id: com.github.IsmaelMartinez.teams_for_linux
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: teams-for-linux
 separate-locales: false


### PR DESCRIPTION
Currently, screensharing fails on Sway/wlroots/xdg-desktop-portal-wlr [1].

This allows screensharing to work with wlroots [2].

The same could be achieved by bundling Pipewire 3.40 or above [3].

[1] emersion/xdg-desktop-portal-wlr#227
[2] flathub/org.chromium.Chromium#243
[3] flathub/org.chromium.Chromium#229