### PR TITLE
Bump to v1.4.16

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,23 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.15" date="2024-03-26">
+			<description>
+				<ul>
+					<li>Added bail out logic to the angular detection as this is
+					creating some memory issues in some users.</li>
+				</ul>
+			</description>
+		</release>
+		<release version="1.4.14" date="2024-03-11">
+			<description>
+				<ul>
+					<li>Electron version upgraded to 29.1.1 by @jijojosephk</li>
+					<li>Fix: #1137 reported by @dschrempf</li>
+					<li>Updated documentation by @andreaippo</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.13" date="2024-03-04">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
+++ b/com.github.IsmaelMartinez.teams_for_linux.appdata.xml
@@ -14,6 +14,16 @@
 	<url type="bugtracker">https://github.com/IsmaelMartinez/teams-for-linux/issues</url>
 	<launchable type="desktop-id">com.github.IsmaelMartinez.teams_for_linux.desktop</launchable>
 	<releases>
+		<release version="1.4.16" date="2024-03-28">
+			<description>
+				<ul>
+					<li>removing the angular recurring call to disable some promotions as I suspect is creating a wee leak by @IsmaelMartinez in #1152</li>
+					<li>Hotfix/remove recurring angular call by @IsmaelMartinez in #1153</li>
+					<li>Hotfix/remove recurring angular call by @IsmaelMartinez in #1154</li>
+					<li>add support for changing idle (away) state in Teams2 by @bastidest in #1157</li>
+				</ul>
+			</description>
+		</release>
 		<release version="1.4.15" date="2024-03-26">
 			<description>
 				<ul>

--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -32,8 +32,8 @@ modules:
 
     sources:
       - type: file
-        url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.4.13/teams-for-linux_1.4.13_amd64.deb
-        sha256: fa810fccec7d0bb0b5aa8bc404e76119b77b7e3dcb35e5715ed6dc95eba9ad3e
+        url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.4.15/teams-for-linux_1.4.15_amd64.deb
+        sha256: a98d27c0e2553f90be6e3eb3056e79a3d20a01367c3f0476aec7ceb1540906ec
       - type: file
         path: com.github.IsmaelMartinez.teams_for_linux.appdata.xml      
       - type: script

--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -32,8 +32,8 @@ modules:
 
     sources:
       - type: file
-        url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.4.15/teams-for-linux_1.4.15_amd64.deb
-        sha256: a98d27c0e2553f90be6e3eb3056e79a3d20a01367c3f0476aec7ceb1540906ec
+        url: https://github.com/IsmaelMartinez/teams-for-linux/releases/download/v1.4.16/teams-for-linux_1.4.16_amd64.deb
+        sha256: 8507a00f3a562abafa8382d235027eb361fb0464ae01db242266e17e226cd968
       - type: file
         path: com.github.IsmaelMartinez.teams_for_linux.appdata.xml      
       - type: script


### PR DESCRIPTION
This PR bumps teams-for-linux to v1.4.16, which includes the patches that makes Teams 2.0 work without leaking too much memory; see https://github.com/IsmaelMartinez/teams-for-linux/issues/1129.