### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -86,5 +86,5 @@ modules:
       - install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
       - desktop-file-edit --set-key Exec --set-value "teams-for-linux %U" ${FLATPAK_DEST}/share/applications/teams-for-linux.desktop
       # required for wayland, cf. https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name
-      - patch-desktop-filename ${FLATPAK_DEST}/teams-for-linux/resources/app.asar
+      - patch-electron-desktop-filename ${FLATPAK_DEST}/teams-for-linux/resources/app.asar
       - rm -rf "${FLATPAK_DEST}/share/icons/hicolor/1024x1024/"


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.