### PR TITLE
fix: force --ozone-platform=x11 and allow login1 on the system bus

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -9,7 +9,9 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --socket=wayland
-  - --socket=fallback-x11
+  # x11, not fallback-x11: the wrapper forces --ozone-platform=x11, so the X11
+  # socket is needed on Wayland sessions too, where fallback-x11 withholds it.
+  - --socket=x11
   - --socket=pulseaudio
   - --share=network
   - --device=all
@@ -22,7 +24,6 @@ finish-args:
   - --talk-name=org.gtk.Notifications
   - --talk-name=org.gnome.SessionManager
   - --env=XDG_CURRENT_DESKTOP=Unity
-  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 rename-desktop-file: teams-for-linux.desktop
@@ -73,7 +74,10 @@ modules:
         dest-filename: teams-for-linux.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/teams-for-linux/teams-for-linux "$@"
+          # Matches upstream's linux.executableArgs, which every other package
+          # gets from electron-builder. desktop-file-edit below rewrites the Exec
+          # line and drops it. Before "$@" so users can still override it.
+          - exec zypak-wrapper /app/teams-for-linux/teams-for-linux --ozone-platform=x11 "$@"
 
     build-commands:
       - ar x teams-for-linux.deb

--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -23,6 +23,9 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gtk.Notifications
   - --talk-name=org.gnome.SessionManager
+  # Electron's powerMonitor watches PrepareForSleep on the system bus, so the
+  # app's suspend/resume handlers never fire without this.
+  - --system-talk-name=org.freedesktop.login1
   - --env=XDG_CURRENT_DESKTOP=Unity
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
Two small sandbox fixes, one commit each.

**Force `--ozone-platform=x11`.** Upstream sets `linux.executableArgs` to
`--ozone-platform=x11`, so deb, rpm, AppImage, tar.gz and snap all force X11. The
`desktop-file-edit` step here rewrites the Exec line and drops it, which since
Electron 38 made `auto` the built-in default has left Flatpak as the only channel
running native Wayland. This reapplies the flag in the wrapper script, switches
`fallback-x11` to `x11` because the flag needs the X11 socket on Wayland sessions
where `fallback-x11` withholds it, and drops `ELECTRON_OZONE_PLATFORM_HINT`, which
Electron 39 removed.

**Allow system-bus `org.freedesktop.login1`.** Electron's `PowerObserverLinux` takes
the shared system bus and subscribes to `PrepareForSleep`, so without
`--system-talk-name` the app's suspend and resume handlers never fire in the sandbox.
Upstream uses them to refresh the Teams connection after the machine wakes.

The socket change is the part worth a runtime check on a Wayland session before merge.

Refs: IsmaelMartinez/teams-for-linux#2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
