### PR TITLE
fix: allow system-bus login1 so suspend/resume handlers fire

### DIFF
--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -25,7 +25,6 @@ finish-args:
   # app's suspend/resume handlers never fire without this.
   - --system-talk-name=org.freedesktop.login1
   - --env=XDG_CURRENT_DESKTOP=Unity
-  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   # required to fix cursor scaling on wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 rename-desktop-file: teams-for-linux.desktop

--- a/com.github.IsmaelMartinez.teams_for_linux.yml
+++ b/com.github.IsmaelMartinez.teams_for_linux.yml
@@ -21,6 +21,9 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gtk.Notifications
   - --talk-name=org.gnome.SessionManager
+  # Electron's powerMonitor watches PrepareForSleep on the system bus, so the
+  # app's suspend/resume handlers never fire without this.
+  - --system-talk-name=org.freedesktop.login1
   - --env=XDG_CURRENT_DESKTOP=Unity
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   # required to fix cursor scaling on wayland


### PR DESCRIPTION
Two small packaging fixes. Supersedes #210, which also forced `--ozone-platform=x11`; that part is dropped pending an upstream decision on whether the X11 pin is still warranted on Electron 42.

`--system-talk-name=org.freedesktop.login1` lets Electron's `powerMonitor` receive `PrepareForSleep`, so the app's resume handlers actually fire inside the sandbox. `app/connectionManager/index.js:46` refreshes the Teams connection on wake and `app/mainAppWindow/index.js:1277` clears expired auth cookies; both are dead in the Flatpak today and work on every other channel.

`ELECTRON_OZONE_PLATFORM_HINT` was deprecated in Electron 38 and removed in 39. The app ships Electron 42, so the line is a no-op.

This needs `finish-args-login1-system-talk-name` added to the app's entry in flatpak-builder-lint's `exceptions.json` — Flatpak's talk-name granularity is per bus name and there is no portal equivalent for `PrepareForSleep`.

Refs: IsmaelMartinez/teams-for-linux#2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
