### PR TITLE
docs: add README and route app issues upstream

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Application bug or feature request
+    url: https://github.com/IsmaelMartinez/teams-for-linux/issues
+    about: Anything about the app itself belongs in the upstream tracker. Open issues here only for the Flatpak build environment (manifest, sandbox permissions, runtime).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Teams for Linux Flatpak packaging
+
+This repository holds the Flathub packaging for [Teams for Linux](https://github.com/IsmaelMartinez/teams-for-linux). It repacks the deb that upstream publishes on each release, so the application code is identical to the other Linux packages.
+
+Issues here are only for the build environment, meaning the manifest, the sandbox permissions (finish-args), the base runtime and anything else specific to the Flatpak build. Anything about the application itself, such as sign in, calls, notifications, crashes or feature requests, belongs in the [upstream tracker](https://github.com/IsmaelMartinez/teams-for-linux/issues). If in doubt, open it upstream.
+
+Version updates are automated. A bot opens a pull request for every upstream release and the Flathub buildbot builds it. Every pull request gets an installable test bundle, so testing those bundles is the most useful way to help.


### PR DESCRIPTION
Adds a short README and an issue template contact link so application level reports go to the upstream tracker; issues in this repo stay scoped to the build environment.

Refs: IsmaelMartinez/teams-for-linux#2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)